### PR TITLE
Use the new login

### DIFF
--- a/vscode/src/utils.ts
+++ b/vscode/src/utils.ts
@@ -167,7 +167,7 @@ export async function selectDevice(ctx: CommandContext, activeOnly: boolean): Pr
   return device;
 }
 
-async function login(ctx: CommandContext, _user: string, _password: string): Promise<void> {
+async function login(ctx: CommandContext): Promise<void> {
   await execFile(ctx.toitExec, [ "auth", "login" ]);
 }
 
@@ -217,7 +217,7 @@ export async function ensureAuth(ctx: CommandContext): Promise<void> {
   const password = await Window.showInputBox(passwordPromptOptions);
   if (!password) throw new Error("No password provided");
 
-  await login(ctx, user, password);
+  await login(ctx);
   ctx.refreshDeviceView();
 }
 


### PR DESCRIPTION
With this change, your browser will open `toit.io` when you need to authenticate (with the old way a failed login attempt could result in your password being displayed in clear text as part of the error message).