### PR TITLE
Use toit.Path as default for LSP

### DIFF
--- a/vscode/src/lspClient.ts
+++ b/vscode/src/lspClient.ts
@@ -62,7 +62,7 @@ function startToitLsp(_: ExtensionContext,
   let debugClientToServer = !!lspSettings.get("debug.clientToServer");
 
   if (toitPath === null || toitPath === undefined) {
-    toitPath = getToitPath(); // Assume `toit` is visible in the global environment.
+    toitPath = getToitPath();
   }
   if (lspArguments === null || lspArguments === undefined) {
     lspArguments = [ "tool", "lsp" ];


### PR DESCRIPTION
This fixes an unintentional change where the lsp toitpath is not used.