### PR TITLE
Remove model from toit serial monitor

### DIFF
--- a/vscode/src/toitMonitor.ts
+++ b/vscode/src/toitMonitor.ts
@@ -14,7 +14,7 @@ async function serialMonitor(ctx: CommandContext) {
     const port = await selectPort(ctx);
     const terminal = ctx.serialTerminal(port);
     terminal.show();
-    terminal.sendText(`${ctx.toitExec} serial monitor --port '${port}' --model esp32-4mb`);
+    terminal.sendText(`${ctx.toitExec} serial monitor --port '${port}'`);
   } catch (e) {
     return Window.showErrorMessage(`Unable to monitor: ${e.message}`);
   }


### PR DESCRIPTION
The model was, apparently, removed from the CLI command.