### PR TITLE
Fix `getToitPath` for LSP client.

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -187,9 +187,8 @@
                         "string",
                         "null"
                     ],
-                    "default": "toit",
                     "description": "The path to the 'toit' command line tool.",
-                    "deprecationMessage": "Deprecated: Please use toit.Path instead."
+                    "deprecationMessage": "Deprecated: Use toit.Path instead."
                 },
                 "toitLanguageServer.arguments": {
                     "type": [

--- a/vscode/src/lspClient.ts
+++ b/vscode/src/lspClient.ts
@@ -65,7 +65,7 @@ function startToitLsp(_: ExtensionContext,
   let lspArguments: Array<string> | string | null | undefined = lspSettings.get("arguments");
   let debugClientToServer = !!lspSettings.get("debug.clientToServer");
 
-  if (toitPath === null || toitPath === undefined) {
+  if (toitPath === null || toitPath === undefined || toitPath === "") {
     toitPath = getToitPath();
   }
   if (lspArguments === null || lspArguments === undefined) {


### PR DESCRIPTION
When the configuration `toitLanguageServer.toitPath` didn't exist, getting its
configuration returned "toit", since that was its default value.
Even without a default value, the config-getter returns an empty string.
We need to remove the default value, and guard against the empty string
(and not just `undefined` and `null`), if we want to fall back to the
"correct" `getToitPath`.