### PR TITLE
Prompt for authentication

### DIFF
--- a/vscode/src/utils.ts
+++ b/vscode/src/utils.ts
@@ -232,7 +232,6 @@ async function consoleContext(ctx: Context): Promise<string> {
 }
 
 export async function ensureAuth(ctx: Context): Promise<void> {
-  ctx.toitOutput("ensure auth\n");
   if (await consoleContext(ctx) === "local") return;
 
   if (await isAuthenticated(ctx)) return;

--- a/vscode/src/utils.ts
+++ b/vscode/src/utils.ts
@@ -227,13 +227,23 @@ async function consoleContext(ctx: Context): Promise<string> {
 }
 
 export async function ensureAuth(ctx: Context): Promise<void> {
+  ctx.toitOutput("ensure auth\n");
   if (await consoleContext(ctx) === "local") return;
 
   if (await isAuthenticated(ctx)) return;
 
+  await promptLogin(ctx);
+}
+
+async function promptLogin(ctx: Context) {
+  const response = await Window.showWarningMessage("Authenticate with toit.io to use the Toit extension.", "Log in");
+  if (!response) return;
+
   await login(ctx);
-  ctx.refreshDeviceView();
-  ctx.refreshSerialView();
+  if (isAuthenticated(ctx)) {
+    ctx.refreshDeviceView();
+    ctx.refreshSerialView();
+  }
 }
 
 export interface WiFiInfo {


### PR DESCRIPTION
At this time, the CLI does not respect the `-s` flag for `toit auth info` which means that this won't really help. 