### PR TITLE
Update change log and version number

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -4,8 +4,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.1.0] - 2021-06-25
+### Added
+- Device view with run and deploy buttons.
+- Start simulator button in the device view.
+- Stop simulator button in for every simulated device in the device view.
+- Serial view with monitor and provision button for each serial port.
+- Jump to device from serial view.
+- Status bar with active organization and firmware version.
+- Change organization from the status bar.
 
 ## [1.0.0] - 2021-04-09
 ### Added
 - Release of 1.0.0.
+- LSP client.
+- Syntax highlighting.

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -3,6 +3,7 @@
     "displayName": "Toit",
     "description": "Toit Programming Language Support",
     "publisher": "toit",
+    "version": "1.1.0",
     "license": "MIT",
     "engines": {
         "vscode": "^1.55.0"
@@ -279,6 +280,5 @@
         "ovsx": "^0.2.0",
         "vsce": "^1.77.0",
         "vscode-languageclient": "^5.2.1"
-    },
-    "version": "1.0.0"
+    }
 }


### PR DESCRIPTION
The changelog and versioning has not been kept up to date. This adjust the change log, so it is closer to the reality and bumps the version number to 1.1.0.