### PR TITLE
Select file for run and deploy when active file is invalid

### DIFF
--- a/vscode/src/toitExec.ts
+++ b/vscode/src/toitExec.ts
@@ -10,12 +10,12 @@ import { } from "./deviceView";
 import { Context, ensureAuth, selectDevice } from "./utils";
 
 
-function currentFilePath(): string {
+function currentFilePath(suffix: string): string {
   const editor = Window.activeTextEditor;
   if (!editor) throw new Error("No active file.");
 
   const filePath = editor.document.fileName;
-  if (!(filePath.endsWith(".toit") || filePath.endsWith(".yaml"))) {
+  if (!(filePath.endsWith(suffix))) {
     throw new Error(`In valid extension: ${filePath}.`);
   }
   return filePath;
@@ -24,7 +24,7 @@ function currentFilePath(): string {
 async function executeRunCommand(ctx: Context, device?: Device) {
   let filePath: string;
   try {
-    filePath = currentFilePath();
+    filePath = currentFilePath(".toit");
   } catch (e) {
     Window.showErrorMessage(`Unable to run or deploy: ${e}`);
     return;
@@ -55,7 +55,7 @@ async function executeRunCommand(ctx: Context, device?: Device) {
 async function executeDeployCommand(ctx: Context, device?: Device) {
   let filePath: string;
   try {
-    filePath = currentFilePath();
+    filePath = currentFilePath(".yaml");
   } catch (e) {
     Window.showErrorMessage(`Unable to deploy file: ${e}`);
     return;

--- a/vscode/src/toitExec.ts
+++ b/vscode/src/toitExec.ts
@@ -17,7 +17,7 @@ async function pickFile(dialogOptions: OpenDialogOptions): Promise<string | unde
   return fileURI[0].path;
 }
 
-async function executeFilePath(suffix: string, dialogOptions: OpenDialogOptions): Promise<string | undefined> {
+async function getExecuteFilePath(suffix: string, dialogOptions: OpenDialogOptions): Promise<string | undefined> {
   const editor = Window.activeTextEditor;
   if (!editor) return await pickFile(dialogOptions);
 
@@ -28,7 +28,7 @@ async function executeFilePath(suffix: string, dialogOptions: OpenDialogOptions)
 }
 
 async function executeRunCommand(ctx: Context, device?: Device) {
-  const filePath = await executeFilePath(".toit", {
+  const filePath = await getExecuteFilePath(".toit", {
     "canSelectMany": false,
     "filters": {"Toit": ["toit"]},
     "title": "Select Toit-file to run"
@@ -59,7 +59,7 @@ async function executeRunCommand(ctx: Context, device?: Device) {
 }
 
 async function executeDeployCommand(ctx: Context, device?: Device) {
-  const filePath = await executeFilePath(".yaml", {
+  const filePath = await getExecuteFilePath(".yaml", {
     "canSelectMany": false,
     "filters": {"YAML": ["yaml"]},
     "title": "Select YAML-file to deploy"

--- a/vscode/src/toitExec.ts
+++ b/vscode/src/toitExec.ts
@@ -10,15 +10,13 @@ import { } from "./deviceView";
 import { Context, ensureAuth, selectDevice } from "./utils";
 
 
-function currentFilePath(ctx: Context, suffix: string): string {
+function currentFilePath(): string {
   const editor = Window.activeTextEditor;
   if (!editor) throw new Error("No active file.");
 
   const filePath = editor.document.fileName;
-  if (!filePath.endsWith(suffix)) {
-    const lastFile = ctx.cache.getLastFile(suffix);
-    if (lastFile) return lastFile;
-    throw new Error(`Non-'${suffix}'-file: ${filePath}.`);
+  if (!(filePath.endsWith(".toit") || filePath.endsWith(".yaml"))) {
+    throw new Error(`In valid extension: ${filePath}.`);
   }
   return filePath;
 }
@@ -26,9 +24,9 @@ function currentFilePath(ctx: Context, suffix: string): string {
 async function executeRunCommand(ctx: Context, device?: Device) {
   let filePath: string;
   try {
-    filePath = currentFilePath(ctx, ".toit");
+    filePath = currentFilePath();
   } catch (e) {
-    Window.showErrorMessage(`Unable to run file: ${e}`);
+    Window.showErrorMessage(`Unable to run or deploy: ${e}`);
     return;
   }
 
@@ -49,7 +47,6 @@ async function executeRunCommand(ctx: Context, device?: Device) {
     cp.stdout?.on("data", (message) => {
       out.send(fileName, message);
     });
-    ctx.cache.setLastFile(".toit", filePath);
   } catch (e) {
     Window.showErrorMessage(`Run app failed: ${e}`);
   }
@@ -58,7 +55,7 @@ async function executeRunCommand(ctx: Context, device?: Device) {
 async function executeDeployCommand(ctx: Context, device?: Device) {
   let filePath: string;
   try {
-    filePath = currentFilePath(ctx, ".yaml");
+    filePath = currentFilePath();
   } catch (e) {
     Window.showErrorMessage(`Unable to deploy file: ${e}`);
     return;
@@ -85,7 +82,6 @@ async function executeDeployCommand(ctx: Context, device?: Device) {
       out.send(fileName, stderr);
     }
     ctx.views.refreshDeviceView(device);
-    ctx.cache.setLastFile(".yaml", filePath);
   } catch (e) {
     Window.showErrorMessage(`Deploy app failed: ${e}`);
   }

--- a/vscode/src/toitExec.ts
+++ b/vscode/src/toitExec.ts
@@ -3,32 +3,38 @@
 // found in the LICENSE file.
 
 import { basename } from "path";
-import { window as Window } from "vscode";
+import { OpenDialogOptions, window as Window } from "vscode";
 import { toitExecFile, toitExecFilePromise } from "./cli";
 import { Device } from "./device";
 import { } from "./deviceView";
 import { Context, ensureAuth, selectDevice } from "./utils";
 
 
-function currentFilePath(suffix: string): string {
+async function pickFile(dialogOptions: OpenDialogOptions): Promise<string | undefined> {
+  const fileURI = await Window.showOpenDialog(dialogOptions);
+  if (!fileURI) return;  // File selection prompt dismissed.
+
+  return fileURI[0].path;
+}
+
+async function executeFilePath(suffix: string, dialogOptions: OpenDialogOptions): Promise<string | undefined> {
   const editor = Window.activeTextEditor;
-  if (!editor) throw new Error("No active file.");
+  if (!editor) return await pickFile(dialogOptions);
 
   const filePath = editor.document.fileName;
-  if (!(filePath.endsWith(suffix))) {
-    throw new Error(`In valid extension: ${filePath}.`);
-  }
+  if (!(filePath.endsWith(suffix))) return await pickFile(dialogOptions);
+
   return filePath;
 }
 
 async function executeRunCommand(ctx: Context, device?: Device) {
-  let filePath: string;
-  try {
-    filePath = currentFilePath(".toit");
-  } catch (e) {
-    Window.showErrorMessage(`Unable to run or deploy: ${e}`);
-    return;
-  }
+  const filePath = await executeFilePath(".toit", {
+    "canSelectMany": false,
+    "filters": {"Toit": ["toit"]},
+    "title": "Select Toit-file to run"
+  });
+
+  if (!filePath) return;
 
   if (!await ensureAuth(ctx)) return;
 
@@ -53,13 +59,12 @@ async function executeRunCommand(ctx: Context, device?: Device) {
 }
 
 async function executeDeployCommand(ctx: Context, device?: Device) {
-  let filePath: string;
-  try {
-    filePath = currentFilePath(".yaml");
-  } catch (e) {
-    Window.showErrorMessage(`Unable to deploy file: ${e}`);
-    return;
-  }
+  const filePath = await executeFilePath(".yaml", {
+    "canSelectMany": false,
+    "filters": {"YAML": ["yaml"]},
+    "title": "Select YAML-file to deploy"
+  });
+  if (!filePath) return;
 
   if (!await ensureAuth(ctx)) return;
 

--- a/vscode/src/utils.ts
+++ b/vscode/src/utils.ts
@@ -40,15 +40,6 @@ export class Context {
 class Cache {
   lastSelectedDevice?: RelatedDevice;
   lastSelectedPort?: string;
-  lastFiles: Map<string, string> = new Map();
-
-  setLastFile(extension: string, path: string): void {
-    this.lastFiles.set(extension, path);
-  }
-
-  getLastFile(extension: string): string | undefined {
-    return this.lastFiles.get(extension);
-  }
 
   lastDevice(): Device | undefined {
     return this.lastSelectedDevice?.device();


### PR DESCRIPTION
If the active file in the editor has the wrong extension, then we prompt the user for a file.