### PR TITLE
Fix syntax for foo-bar--.

### DIFF
--- a/vscode/syntaxes/toit.tmLanguage.json
+++ b/vscode/syntaxes/toit.tmLanguage.json
@@ -741,19 +741,19 @@
       "patterns": [
         {
           "name": "entity.name.type.toit",
-          "match": "\\b(?<!-)_?[A-Z][0-9]*(?!-)\\b[?]?"
+          "match": "\\b(?<!-)_?[A-Z][0-9]*(?<!-)\\b[?]?"
         },
         {
           "name": "entity.name.type.toit",
-          "match": "\\b(?<!-)_?[A-Z][A-Z_-]*[a-z][\\w-]*(?!-)\\b[?]?"
+          "match": "\\b(?<!-)_?[A-Z][A-Z_-]*[a-z][\\w-]*(?<!-)\\b[?]?"
         },
         {
           "name": "entity.name.type.shorts.toit",
-          "match": "\\b(?<!-)(int|bool|float|string)(?!-)\\b[?]?"
+          "match": "\\b(?<!-)(int|bool|float|string)(?<!-)\\b[?]?"
         },
         {
           "name": "entity.name.type.any_none.toit",
-          "match": "\\b(?<!-)(any|none)(?!-)\\b"
+          "match": "\\b(?<!-)(any|none)(?<!-)\\b"
         }
       ]
     },
@@ -761,7 +761,7 @@
       "patterns": [
         {
           "name": "entity.name.function.call.toit",
-          "match": "\\b(?<!-)[\\p{L}_][\\w-]*(?!-)\\b"
+          "match": "\\b(?<!-)[\\p{L}_][\\w-]*(?<!-)\\b"
         }
       ]
     },

--- a/vscode/syntaxes/toit.tmLanguage.yaml
+++ b/vscode/syntaxes/toit.tmLanguage.yaml
@@ -460,18 +460,18 @@ repository:
     #  - single capitalized character followed by a number -> also a type: `class C1`.
     #  - capitalized identifier with at least on lower-case character: a type.
     - name: entity.name.type.toit
-      match: \b(?<!-)_?[A-Z][0-9]*(?!-)\b[?]?
+      match: \b(?<!-)_?[A-Z][0-9]*(?<!-)\b[?]?
     - name: entity.name.type.toit
-      match: \b(?<!-)_?[A-Z][A-Z_-]*[a-z][\w-]*(?!-)\b[?]?
+      match: \b(?<!-)_?[A-Z][A-Z_-]*[a-z][\w-]*(?<!-)\b[?]?
     - name: entity.name.type.shorts.toit
-      match: \b(?<!-)(int|bool|float|string)(?!-)\b[?]?
+      match: \b(?<!-)(int|bool|float|string)(?<!-)\b[?]?
     - name: entity.name.type.any_none.toit
-      match: \b(?<!-)(any|none)(?!-)\b
+      match: \b(?<!-)(any|none)(?<!-)\b
 
   variable:
     patterns:
       - name: entity.name.function.call.toit
-        match: \b(?<!-)[\p{L}_][\w-]*(?!-)\b
+        match: \b(?<!-)[\p{L}_][\w-]*(?<!-)\b
 
   primitive:
     patterns:


### PR DESCRIPTION
An identifier is not allowed to finish with '-'. We were using a look-ahead instead of a look-behind.