### PR TITLE
Fix version number

### DIFF
--- a/.github/workflows/vscode.yml
+++ b/.github/workflows/vscode.yml
@@ -68,7 +68,7 @@ jobs:
           VERSION_WITHOUT_V=$(echo $VERSION | sed 's/^v//')
           yarn version --new-version $VERSION_WITHOUT_V --allow-same-version
           yarn run package
-          if [[ "${{ github.event_name }}" == "release" && "$VERSION_WITHOUT_V" != "$VERSION ]]; then
+          if [[ "${{ github.event_name }}" == "release" && "$VERSION_WITHOUT_V" != "$VERSION" ]]; then
             cp toit-*.vsix toit-${{ steps.constants.outputs.version }}.vsix
           fi
 

--- a/.github/workflows/vscode.yml
+++ b/.github/workflows/vscode.yml
@@ -64,8 +64,13 @@ jobs:
       - name: Build package
         working-directory: ${{ env.vscode-dir }}
         run: |
-          yarn version --new-version ${{ steps.constants.outputs.version }} --allow-same-version
+          VERSION=${{ steps.constants.outputs.version }}
+          VERSION_WITHOUT_V=$(echo $VERSION | sed 's/^v//')
+          yarn version --new-version $VERSION_WITHOUT_V --allow-same-version
           yarn run package
+          if [[ "${{ github.event_name }}" == "release" && "$VERSION_WITHOUT_V" != "$VERSION ]]; then
+            cp toit-*.vsix toit-${{ steps.constants.outputs.version }}.vsix
+          fi
 
       - name: Upload vsix artifact
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
The version we give to `yarn` must not start with a `v`. However, the vsix file should have the 'v' in it. So we have to trim it first and then rename the produced file.